### PR TITLE
Fix missing bottom border for bootstrap 4.6.0

### DIFF
--- a/dist/css/responsive-tabs.css
+++ b/dist/css/responsive-tabs.css
@@ -21,6 +21,7 @@
         display: none; 
         border: 0 !important; 
         border-radius: 0 !important;
+        margin-bottom: 0 !important;
     }
     .responsive-tabs.open li > a, .responsive-tabs li > a.active {
         display: block;

--- a/home.html
+++ b/home.html
@@ -4,7 +4,7 @@
 	<title>Bootstrap 4 Tabs Responsive </title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> 
 	<meta name="description" content="Bootstrap responsive will turn the bootstrap nav tabs into dropdown in below 768px screensize"> 
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
 	<link href="dist/css/responsive-tabs.css" rel="stylesheet">
 	<link rel="icon" href="favicon.ico" type="image/ico" sizes="16x16"> 
 	<link href="style.css" rel="stylesheet">  
@@ -46,7 +46,7 @@
 
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js" integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
 <script src="dist/js/responsive-tabs.js"></script>
 
 


### PR DESCRIPTION
In Bootstrap 4.6.0, as a result of https://github.com/twbs/bootstrap/pull/32211, the bottom border is not visible in the responsive-tab in small mode.

![Screen Shot 2021-09-09 at 4 05 38 PM](https://user-images.githubusercontent.com/149304/132757352-c17f1dda-4671-4b50-a1b5-d40caa264da5.png)


This fixes it.

Thank you for sharing this very clever solution!  I'm glad I found it googling. 